### PR TITLE
Feat/contract-upgrades-frontend

### DIFF
--- a/packages/contracts/deployments/goerli.json
+++ b/packages/contracts/deployments/goerli.json
@@ -1,6 +1,6 @@
 {
   "network": "goerli",
-  "factory": "0x566ac8344a7cbBC4879e5692F32A9ebdED002e7f",
+  "factory": "0x546adED0B0179d550e87cf909939a1207Fd26fB7",
   "txHash": "0xf6dc8248782f619b6d8d092e13c68166811d541a2b90f3753f4c8d89930f1fb5",
   "blockNumber": "7640975"
 }

--- a/packages/dapp/src/config.js
+++ b/packages/dapp/src/config.js
@@ -55,7 +55,7 @@ export const CONFIG = {
       WRAPPED_NATIVE_TOKEN:
         '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6'.toLowerCase(),
       INVOICE_FACTORY:
-        '0x566ac8344a7cbBC4879e5692F32A9ebdED002e7f'.toLowerCase(),
+        '0x546adED0B0179d550e87cf909939a1207Fd26fB7'.toLowerCase(),
       RESOLVERS: {
         ['0x1206b51217271FC3ffCa57d0678121983ce0390E'.toLowerCase()]: {
           name: 'LexDAO',

--- a/packages/dapp/src/context/CreateContext.jsx
+++ b/packages/dapp/src/context/CreateContext.jsx
@@ -60,9 +60,6 @@ export const CreateContextProvider = ({ children }) => {
   const [tx, setTx] = useState();
   const [loading, setLoading] = useState(false);
 
-  // const hre = require('hardhat');
-  // const factory = await hre.ethers.getContractAt("SmartInvoiceFactory", "0x546adED0B0179d550e87cf909939a1207Fd26fB7");
-
   // step handling
   const [currentStep, setStep] = useState(1);
   const [nextStepEnabled, setNextStepEnabled] = useState(false);

--- a/packages/dapp/src/context/CreateContext.jsx
+++ b/packages/dapp/src/context/CreateContext.jsx
@@ -11,6 +11,7 @@ import React, {
 import {
   getResolvers,
   getWrappedNativeToken,
+  getInvoiceFactoryAddress,
   isValidLink,
   logError,
 } from '../utils/helpers';
@@ -52,12 +53,15 @@ export const CreateContextProvider = ({ children }) => {
   const [milestones, setMilestones] = useState('1');
   const [termsAccepted, setTermsAccepted] = useState(false);
   const [arbitrationProvider, setArbitrationProvider] = useState(RESOLVERS[0]);
-  const [requireVerificaiton, setRequireVerification] = useState(true);
+  const [requireVerification, setRequireVerification] = useState(true);
 
   // payments chunks
   const [payments, setPayments] = useState([BigNumber.from(0)]);
   const [tx, setTx] = useState();
   const [loading, setLoading] = useState(false);
+
+  // const hre = require('hardhat');
+  // const factory = await hre.ethers.getContractAt("SmartInvoiceFactory", "0x546adED0B0179d550e87cf909939a1207Fd26fB7");
 
   // step handling
   const [currentStep, setStep] = useState(1);
@@ -142,22 +146,50 @@ export const CreateContextProvider = ({ children }) => {
     endDate,
   ]);
 
-  const createInvoice = useCallback(async () => {
+  const createEscrow = useCallback(async () => {
     if (step1Valid && step2Valid && step3Valid && detailsHash) {
       setLoading(true);
       setTx();
 
+      const resolverType = 0; // 0 for individual, 1 for erc-792 arbitrator
+      const escrowType = utils.formatBytes32String('escrow');
+      const factoryAddress = getInvoiceFactoryAddress(chainId);
+      const data = utils.AbiCoder.prototype.encode(
+        [
+          'address',
+          'uint8',
+          'address',
+          'address',
+          'uint256',
+          'bytes32',
+          'address',
+          'bool',
+          'address',
+        ],
+        [
+          clientAddress,
+          resolverType,
+          arbitrationProvider,
+          paymentToken,
+          Math.floor(safetyValveDate / 1000),
+          detailsHash,
+          paymentToken,
+          requireVerification,
+          factoryAddress,
+        ],
+      );
+
+      const fee = await provider.getFeeData();
+
+      console.log({ fee });
+
       const transaction = await register(
-        chainId,
+        factoryAddress,
         provider,
-        clientAddress,
         paymentAddress,
-        arbitrationProvider,
-        paymentToken,
         payments,
-        Math.floor(safetyValveDate / 1000),
-        detailsHash,
-        requireVerificaiton,
+        data,
+        escrowType,
       ).catch(registerError => {
         logError({ registerError });
         setLoading(false);
@@ -177,7 +209,7 @@ export const CreateContextProvider = ({ children }) => {
     payments,
     safetyValveDate,
     detailsHash,
-    requireVerificaiton,
+    requireVerification,
     step1Valid,
     step2Valid,
     step3Valid,
@@ -201,11 +233,11 @@ export const CreateContextProvider = ({ children }) => {
 
   const nextStepHandler = useCallback(() => {
     if (nextStepEnabled) {
-      if (currentStep === 4) return createInvoice();
+      if (currentStep === 4) return createEscrow();
       setStep(prevState => prevState + 1);
     }
     return () => undefined;
-  }, [nextStepEnabled, currentStep, createInvoice]);
+  }, [nextStepEnabled, currentStep, createEscrow]);
 
   return (
     <CreateContext.Provider
@@ -246,7 +278,7 @@ export const CreateContextProvider = ({ children }) => {
         setPayments,
         // creating invoice
         loading,
-        createInvoice,
+        createEscrow,
         // stepHandling
         currentStep,
         nextStepEnabled,

--- a/packages/dapp/src/utils/invoice.js
+++ b/packages/dapp/src/utils/invoice.js
@@ -3,38 +3,23 @@ import { Contract, utils } from 'ethers';
 import { getInvoiceFactoryAddress, logError } from './helpers';
 
 export const register = async (
-  chainId,
+  factoryAddress,
   ethersProvider,
-  client,
   provider,
-  resolver,
-  token,
-  amounts, // array of milestone payments in wei
-  terminationTime, // time in seconds since epoch
-  detailsHash, // 32 bits hex
-  requireVerification,
+  amounts,
+  data,
+  type,
 ) => {
   const abi = new utils.Interface([
-    'function create(address client, address provider, uint8 resolverType, address resolver, address token, uint256[] calldata amounts, uint256 terminationTime, bytes32 details, bool requireVerification) public',
+    'function create(address _recipient, uint256[] calldata _amounts, bytes _data, bytes32 _type) public',
   ]);
   const contract = new Contract(
-    getInvoiceFactoryAddress(chainId),
+    factoryAddress,
     abi,
     ethersProvider.getSigner(),
   );
 
-  const resolverType = 0; // 0 for individual, 1 for erc-792 arbitrator
-  return contract.create(
-    client,
-    provider,
-    resolverType,
-    resolver,
-    token,
-    amounts,
-    terminationTime,
-    detailsHash,
-    requireVerification,
-  );
+  return contract.create(provider, amounts, data, type);
 };
 
 export const getResolutionRateFromFactory = async (


### PR DESCRIPTION
1. Frontend deploys using the new factory
2. New Goerli factory

As different implementation types will require different encoding, all encoding of invoice-type-specific params takes place in `CreateContext.js` in `CreateEscrow()` (previously `CreateInvoice()`) then passed to `register`.  

`register` should never need to be altered for future invoice types; all invoice customization should ideally take place in its own type-specific create function (`CreateInstantPay`,` CreateSalaryPay `etc) in `CreateContext.js `that encodes and bundles the necessary params to pass to register.
